### PR TITLE
Fix: use lowercase letters when comparing hash strings

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -90,13 +90,24 @@ jobs:
         run: python -c "import os; exit(not os.path.isfile('different_folder/new_name.py'))"
       - run: ls different_folder && rm -r different_folder
 
-      - name: Test to download a file and match MD5
+      - name: Test to download a file and match MD5 in lowercase
         uses: ./
         id: download-tar-md5
         with:
           file-url: 'https://github.com/carlosperate/download-file-action/archive/refs/tags/v1.0.3.tar.gz'
           file-name: 'name_md5.tar.gz'
           md5: 'e3b51204dedc75588ca164a26b51610d'
+      - name: Test file exists
+        run: python -c "import os, sys; sys.exit(not os.path.isfile('name_md5.tar.gz'))"
+      - run: rm name_md5.tar.gz
+
+      - name: Test to download a file and match MD5 in UPPERCASE
+        uses: ./
+        id: download-tar-md5
+        with:
+          file-url: 'https://github.com/carlosperate/download-file-action/archive/refs/tags/v1.0.3.tar.gz'
+          file-name: 'name_md5.tar.gz'
+          md5: 'E3B51204DEDC75588CA164A26B51610D'
       - name: Test file exists
         run: python -c "import os, sys; sys.exit(not os.path.isfile('name_md5.tar.gz'))"
       - run: rm name_md5.tar.gz
@@ -113,13 +124,24 @@ jobs:
         run: exit 1
       - run: rm download-file-action-1.0.3.tar.gz
 
-      - name: Test to download a file and match SHA256
+      - name: Test to download a file and match SHA256 in lowercase
         uses: ./
         id: download-tar-sha256
         with:
           file-url: 'https://github.com/carlosperate/download-file-action/archive/refs/tags/v1.0.3.tar.gz'
           file-name: 'name_sha256.tar.gz'
           sha256: '76ef5cf6e910a4955f713fb36cca6f90ffeee6ffafe743754716e149d68136de'
+      - name: Test file exists
+        run: python -c "import os, sys; sys.exit(not os.path.isfile('name_sha256.tar.gz'))"
+      - run: rm name_sha256.tar.gz
+
+      - name: Test to download a file and match SHA256 in UPPERCASE
+        uses: ./
+        id: download-tar-sha256
+        with:
+          file-url: 'https://github.com/carlosperate/download-file-action/archive/refs/tags/v1.0.3.tar.gz'
+          file-name: 'name_sha256.tar.gz'
+          sha256: '76EF5CF6E910A4955F713FB36CCA6F90FFEEE6FFAFE743754716E149D68136DE'
       - name: Test file exists
         run: python -c "import os, sys; sys.exit(not os.path.isfile('name_sha256.tar.gz'))"
       - run: rm name_sha256.tar.gz

--- a/dist/index.js
+++ b/dist/index.js
@@ -6475,8 +6475,8 @@ function main() {
             const fileURL = core.getInput('file-url');
             const fileName = core.getInput('file-name') || undefined;
             const fileLocation = core.getInput('location') || process.cwd();
-            const fileMd5 = core.getInput('md5');
-            const fileSha256 = core.getInput('sha256');
+            const fileMd5 = core.getInput('md5').toLowerCase();
+            const fileSha256 = core.getInput('sha256').toLowerCase();
             if (!fileURL) {
                 core.setFailed('The file-url input was not set.');
             }
@@ -6490,7 +6490,7 @@ function main() {
                 filename: fileName,
             });
             filePath = path.normalize(filePath);
-            const downloadMd5 = yield md5_file_1.default(filePath);
+            const downloadMd5 = yield md5_file_1.default(filePath).then(md5Value => md5Value.toLowerCase());
             core.info(`Downloaded file MD5: ${downloadMd5}`);
             if (fileMd5 && downloadMd5 !== fileMd5) {
                 throw new Error(`File MD5 (left) doesn't match expected value (right): ${downloadMd5} != ${fileMd5}`);
@@ -6501,7 +6501,7 @@ function main() {
             const fileBuffer = fs.readFileSync(filePath);
             const hashSum = crypto.createHash('sha256');
             hashSum.update(fileBuffer);
-            const downloadSha256 = hashSum.digest('hex');
+            const downloadSha256 = hashSum.digest('hex').toLowerCase();
             core.info(`Downloaded file SHA256: ${downloadSha256}`);
             if (fileSha256 && downloadSha256 !== fileSha256) {
                 throw new Error(`File SHA256 (left) doesn't match expected value (right): ${downloadSha256} != ${fileSha256}`);
@@ -7067,7 +7067,7 @@ module.exports = function (obj) {
 /***/ 482:
 /***/ (function(module) {
 
-module.exports = {"_from":"got@^8.3.1","_id":"got@8.3.2","_inBundle":false,"_integrity":"sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==","_location":"/got","_phantomChildren":{},"_requested":{"type":"range","registry":true,"raw":"got@^8.3.1","name":"got","escapedName":"got","rawSpec":"^8.3.1","saveSpec":null,"fetchSpec":"^8.3.1"},"_requiredBy":["/"],"_resolved":"https://registry.npmjs.org/got/-/got-8.3.2.tgz","_shasum":"1d23f64390e97f776cac52e5b936e5f514d2e937","_spec":"got@^8.3.1","_where":"/Users/microbit-carlos/workspace/mine/download-file-action","ava":{"concurrency":4},"browser":{"decompress-response":false,"electron":false},"bugs":{"url":"https://github.com/sindresorhus/got/issues"},"bundleDependencies":false,"dependencies":{"@sindresorhus/is":"^0.7.0","cacheable-request":"^2.1.1","decompress-response":"^3.3.0","duplexer3":"^0.1.4","get-stream":"^3.0.0","into-stream":"^3.1.0","is-retry-allowed":"^1.1.0","isurl":"^1.0.0-alpha5","lowercase-keys":"^1.0.0","mimic-response":"^1.0.0","p-cancelable":"^0.4.0","p-timeout":"^2.0.1","pify":"^3.0.0","safe-buffer":"^5.1.1","timed-out":"^4.0.1","url-parse-lax":"^3.0.0","url-to-options":"^1.0.1"},"deprecated":false,"description":"Simplified HTTP requests","devDependencies":{"ava":"^0.25.0","coveralls":"^3.0.0","form-data":"^2.1.1","get-port":"^3.0.0","nyc":"^11.0.2","p-event":"^1.3.0","pem":"^1.4.4","proxyquire":"^1.8.0","sinon":"^4.0.0","slow-stream":"0.0.4","tempfile":"^2.0.0","tempy":"^0.2.1","universal-url":"1.0.0-alpha","xo":"^0.20.0"},"engines":{"node":">=4"},"files":["index.js","errors.js"],"homepage":"https://github.com/sindresorhus/got#readme","keywords":["http","https","get","got","url","uri","request","util","utility","simple","curl","wget","fetch","net","network","electron"],"license":"MIT","maintainers":[{"name":"Sindre Sorhus","email":"sindresorhus@gmail.com","url":"sindresorhus.com"},{"name":"Vsevolod Strukchinsky","email":"floatdrop@gmail.com","url":"github.com/floatdrop"},{"name":"Alexander Tesfamichael","email":"alex.tesfamichael@gmail.com","url":"alextes.me"}],"name":"got","repository":{"type":"git","url":"git+https://github.com/sindresorhus/got.git"},"scripts":{"coveralls":"nyc report --reporter=text-lcov | coveralls","test":"xo && nyc ava"},"version":"8.3.2"};
+module.exports = {"name":"got","version":"8.3.2","description":"Simplified HTTP requests","license":"MIT","repository":"sindresorhus/got","maintainers":[{"name":"Sindre Sorhus","email":"sindresorhus@gmail.com","url":"sindresorhus.com"},{"name":"Vsevolod Strukchinsky","email":"floatdrop@gmail.com","url":"github.com/floatdrop"},{"name":"Alexander Tesfamichael","email":"alex.tesfamichael@gmail.com","url":"alextes.me"}],"engines":{"node":">=4"},"scripts":{"test":"xo && nyc ava","coveralls":"nyc report --reporter=text-lcov | coveralls"},"files":["index.js","errors.js"],"keywords":["http","https","get","got","url","uri","request","util","utility","simple","curl","wget","fetch","net","network","electron"],"dependencies":{"@sindresorhus/is":"^0.7.0","cacheable-request":"^2.1.1","decompress-response":"^3.3.0","duplexer3":"^0.1.4","get-stream":"^3.0.0","into-stream":"^3.1.0","is-retry-allowed":"^1.1.0","isurl":"^1.0.0-alpha5","lowercase-keys":"^1.0.0","mimic-response":"^1.0.0","p-cancelable":"^0.4.0","p-timeout":"^2.0.1","pify":"^3.0.0","safe-buffer":"^5.1.1","timed-out":"^4.0.1","url-parse-lax":"^3.0.0","url-to-options":"^1.0.1"},"devDependencies":{"ava":"^0.25.0","coveralls":"^3.0.0","form-data":"^2.1.1","get-port":"^3.0.0","nyc":"^11.0.2","p-event":"^1.3.0","pem":"^1.4.4","proxyquire":"^1.8.0","sinon":"^4.0.0","slow-stream":"0.0.4","tempfile":"^2.0.0","tempy":"^0.2.1","universal-url":"1.0.0-alpha","xo":"^0.20.0"},"ava":{"concurrency":4},"browser":{"decompress-response":false,"electron":false},"_resolved":"https://registry.npmjs.org/got/-/got-8.3.2.tgz","_integrity":"sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==","_from":"got@8.3.2"};
 
 /***/ }),
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,8 +12,8 @@ async function main(): Promise<void> {
     const fileURL: string = core.getInput('file-url');
     const fileName: string | undefined = core.getInput('file-name') || undefined;
     const fileLocation: string = core.getInput('location') || process.cwd();
-    const fileMd5: string = core.getInput('md5');
-    const fileSha256: string = core.getInput('sha256');
+    const fileMd5: string = core.getInput('md5').toLowerCase();
+    const fileSha256: string = core.getInput('sha256').toLowerCase();
 
     if (!fileURL) {
       core.setFailed('The file-url input was not set.');
@@ -31,7 +31,7 @@ async function main(): Promise<void> {
     });
     filePath = path.normalize(filePath);
 
-    const downloadMd5 = await md5File(filePath);
+    const downloadMd5 = await md5File(filePath).then(md5Value => md5Value.toLowerCase());
     core.info(`Downloaded file MD5: ${downloadMd5}`);
     if (fileMd5 && downloadMd5 !== fileMd5) {
       throw new Error(`File MD5 (left) doesn't match expected value (right): ${downloadMd5} != ${fileMd5}`);
@@ -42,7 +42,7 @@ async function main(): Promise<void> {
     const fileBuffer = fs.readFileSync(filePath);
     const hashSum = crypto.createHash('sha256');
     hashSum.update(fileBuffer);
-    const downloadSha256 = hashSum.digest('hex');
+    const downloadSha256 = hashSum.digest('hex').toLowerCase();
     core.info(`Downloaded file SHA256: ${downloadSha256}`);
     if (fileSha256 && downloadSha256 !== fileSha256) {
       throw new Error(`File SHA256 (left) doesn't match expected value (right): ${downloadSha256} != ${fileSha256}`);


### PR DESCRIPTION
Hi. I encountered the following error:

```
> Run carlosperate/download-file-action@v1
Downloading file:
	url: ...
	MD5: 9E107D9D372BB6826BD81D3542A419D6
Downloaded file MD5: 9e107d9d372bb6826bd81d3542a419d6
Error: File MD5 (left) doesn't match expected value (right): 9e107d9d372bb6826bd81d3542a419d6 != 9E107D9D372BB6826BD81D3542A419D6
```

I fixed it. This is an improvement of 976c4b39f5abd1ce8eb03a064fcb6abdc776dfe4 and f4356dc0f45fea2cadcbc567c9717ce53f8b5687 ( #3 ).

If you don't like lowercase letters, just replace all `toLowerCase()` to `toUpperCase()` .

I built this action with Node.js v14.18.3.