### PR TITLE
Fix: throw error if the "file-url" parameter is not set

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -14,6 +14,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Test no "file-url" parameter
+        continue-on-error: true
+        uses: ./
+        id: no-param-file-url
+      - name: Fail workflow if no file-url test didn't raise an error
+        if: steps.no-param-file-url == 'success'
+        run: exit 1
+
       - name: Simple test to download a file
         uses: ./
         id: download-poetry-simple

--- a/dist/index.js
+++ b/dist/index.js
@@ -6472,14 +6472,11 @@ const download = __webpack_require__(446);
 function main() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            const fileURL = core.getInput('file-url');
+            const fileURL = core.getInput('file-url', { required: true });
             const fileName = core.getInput('file-name') || undefined;
             const fileLocation = core.getInput('location') || process.cwd();
             const fileMd5 = core.getInput('md5');
             const fileSha256 = core.getInput('sha256');
-            if (!fileURL) {
-                core.setFailed('The file-url input was not set.');
-            }
             core.info('Downloading file:');
             core.info(`\turl: ${fileURL}`);
             core.info(`\tname: ${fileName || 'Not set'}`);
@@ -7067,7 +7064,7 @@ module.exports = function (obj) {
 /***/ 482:
 /***/ (function(module) {
 
-module.exports = {"_from":"got@^8.3.1","_id":"got@8.3.2","_inBundle":false,"_integrity":"sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==","_location":"/got","_phantomChildren":{},"_requested":{"type":"range","registry":true,"raw":"got@^8.3.1","name":"got","escapedName":"got","rawSpec":"^8.3.1","saveSpec":null,"fetchSpec":"^8.3.1"},"_requiredBy":["/"],"_resolved":"https://registry.npmjs.org/got/-/got-8.3.2.tgz","_shasum":"1d23f64390e97f776cac52e5b936e5f514d2e937","_spec":"got@^8.3.1","_where":"/Users/microbit-carlos/workspace/mine/download-file-action","ava":{"concurrency":4},"browser":{"decompress-response":false,"electron":false},"bugs":{"url":"https://github.com/sindresorhus/got/issues"},"bundleDependencies":false,"dependencies":{"@sindresorhus/is":"^0.7.0","cacheable-request":"^2.1.1","decompress-response":"^3.3.0","duplexer3":"^0.1.4","get-stream":"^3.0.0","into-stream":"^3.1.0","is-retry-allowed":"^1.1.0","isurl":"^1.0.0-alpha5","lowercase-keys":"^1.0.0","mimic-response":"^1.0.0","p-cancelable":"^0.4.0","p-timeout":"^2.0.1","pify":"^3.0.0","safe-buffer":"^5.1.1","timed-out":"^4.0.1","url-parse-lax":"^3.0.0","url-to-options":"^1.0.1"},"deprecated":false,"description":"Simplified HTTP requests","devDependencies":{"ava":"^0.25.0","coveralls":"^3.0.0","form-data":"^2.1.1","get-port":"^3.0.0","nyc":"^11.0.2","p-event":"^1.3.0","pem":"^1.4.4","proxyquire":"^1.8.0","sinon":"^4.0.0","slow-stream":"0.0.4","tempfile":"^2.0.0","tempy":"^0.2.1","universal-url":"1.0.0-alpha","xo":"^0.20.0"},"engines":{"node":">=4"},"files":["index.js","errors.js"],"homepage":"https://github.com/sindresorhus/got#readme","keywords":["http","https","get","got","url","uri","request","util","utility","simple","curl","wget","fetch","net","network","electron"],"license":"MIT","maintainers":[{"name":"Sindre Sorhus","email":"sindresorhus@gmail.com","url":"sindresorhus.com"},{"name":"Vsevolod Strukchinsky","email":"floatdrop@gmail.com","url":"github.com/floatdrop"},{"name":"Alexander Tesfamichael","email":"alex.tesfamichael@gmail.com","url":"alextes.me"}],"name":"got","repository":{"type":"git","url":"git+https://github.com/sindresorhus/got.git"},"scripts":{"coveralls":"nyc report --reporter=text-lcov | coveralls","test":"xo && nyc ava"},"version":"8.3.2"};
+module.exports = {"name":"got","version":"8.3.2","description":"Simplified HTTP requests","license":"MIT","repository":"sindresorhus/got","maintainers":[{"name":"Sindre Sorhus","email":"sindresorhus@gmail.com","url":"sindresorhus.com"},{"name":"Vsevolod Strukchinsky","email":"floatdrop@gmail.com","url":"github.com/floatdrop"},{"name":"Alexander Tesfamichael","email":"alex.tesfamichael@gmail.com","url":"alextes.me"}],"engines":{"node":">=4"},"scripts":{"test":"xo && nyc ava","coveralls":"nyc report --reporter=text-lcov | coveralls"},"files":["index.js","errors.js"],"keywords":["http","https","get","got","url","uri","request","util","utility","simple","curl","wget","fetch","net","network","electron"],"dependencies":{"@sindresorhus/is":"^0.7.0","cacheable-request":"^2.1.1","decompress-response":"^3.3.0","duplexer3":"^0.1.4","get-stream":"^3.0.0","into-stream":"^3.1.0","is-retry-allowed":"^1.1.0","isurl":"^1.0.0-alpha5","lowercase-keys":"^1.0.0","mimic-response":"^1.0.0","p-cancelable":"^0.4.0","p-timeout":"^2.0.1","pify":"^3.0.0","safe-buffer":"^5.1.1","timed-out":"^4.0.1","url-parse-lax":"^3.0.0","url-to-options":"^1.0.1"},"devDependencies":{"ava":"^0.25.0","coveralls":"^3.0.0","form-data":"^2.1.1","get-port":"^3.0.0","nyc":"^11.0.2","p-event":"^1.3.0","pem":"^1.4.4","proxyquire":"^1.8.0","sinon":"^4.0.0","slow-stream":"0.0.4","tempfile":"^2.0.0","tempy":"^0.2.1","universal-url":"1.0.0-alpha","xo":"^0.20.0"},"ava":{"concurrency":4},"browser":{"decompress-response":false,"electron":false},"_resolved":"https://registry.npmjs.org/got/-/got-8.3.2.tgz","_integrity":"sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==","_from":"got@8.3.2"};
 
 /***/ }),
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,15 +9,11 @@ const download = require('./download-mod');
 
 async function main(): Promise<void> {
   try {
-    const fileURL: string = core.getInput('file-url');
+    const fileURL: string = core.getInput('file-url', { required: true });
     const fileName: string | undefined = core.getInput('file-name') || undefined;
     const fileLocation: string = core.getInput('location') || process.cwd();
     const fileMd5: string = core.getInput('md5');
     const fileSha256: string = core.getInput('sha256');
-
-    if (!fileURL) {
-      core.setFailed('The file-url input was not set.');
-    }
 
     core.info('Downloading file:');
     core.info(`\turl: ${fileURL}`);


### PR DESCRIPTION
Original:

```
> Run ...
Error: The file-url input was not set.
Downloading file:
	url: 
	name: Not set
	location: .
	MD5: 
	SHA256: 
Error: Invalid URL
```

**Gotcha**: `core.setFailed` ([code](https://github.com/carlosperate/download-file-action/blob/85e2ad2256cd4a2064540f2313b15b274ad5cd64/src/index.ts#L19)) didn't block the execution.

New:

```
> Run ...
Error: Input required and not supplied: file-url
```