### PR TITLE
CI: perform code tests before functional tests

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -12,6 +12,8 @@ jobs:
       - run: npm run package
       - run: npm run lint
   action-test:
+    needs:
+      - build-lint
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
Let's make the workflow more logical.

This PR conflicts with #17 . We need to modify the dependent job name.